### PR TITLE
Consider memory usage

### DIFF
--- a/akka-guard-core/src/main/scala/com/chatwork/akka/guard/SABBrokerConfig.scala
+++ b/akka-guard-core/src/main/scala/com/chatwork/akka/guard/SABBrokerConfig.scala
@@ -1,10 +1,35 @@
 package com.chatwork.akka.guard
 
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.duration.FiniteDuration
 
 case class SABBrokerConfig(
     maxFailures: Long,
     failureTimeout: FiniteDuration,
     resetTimeout: FiniteDuration,
-    receiveTimeout: Option[Duration] = None
-)
+    receiveTimeout: FiniteDuration,
+    isOneShot: Boolean = true
+) {
+  require(resetTimeout <= receiveTimeout, "resetTimeout <= receiveTimeout")
+}
+
+object SABBrokerConfig {
+  def apply(maxFailures: Long, failureTimeout: FiniteDuration, resetTimeout: FiniteDuration): SABBrokerConfig =
+    new SABBrokerConfig(
+      maxFailures = maxFailures,
+      failureTimeout = failureTimeout,
+      resetTimeout = resetTimeout,
+      receiveTimeout = resetTimeout
+    )
+
+  def apply(maxFailures: Long,
+            failureTimeout: FiniteDuration,
+            resetTimeout: FiniteDuration,
+            isOneShot: Boolean): SABBrokerConfig =
+    new SABBrokerConfig(
+      maxFailures = maxFailures,
+      failureTimeout = failureTimeout,
+      resetTimeout = resetTimeout,
+      receiveTimeout = resetTimeout,
+      isOneShot = isOneShot
+    )
+}


### PR DESCRIPTION
- add `isOneShot` parameter to `SABBrokerConfig`
- if `isOneShot` is enabled, call to `context.stop(self)`